### PR TITLE
feat(pages/index.tsx): load the algolia index client side on load

### DIFF
--- a/components/algolia-instant-search/algolia-instant-search.spec.tsx
+++ b/components/algolia-instant-search/algolia-instant-search.spec.tsx
@@ -12,17 +12,15 @@ jest.mock('../algolia-search-result-list/algolia-search-result-list');
 describe('AlgoliaInstantSearch', () => {
   test('renders component', async () => {
     const component = ShallowRenderer.createRenderer();
+    const mockSearchClient = algoliasearch('id', 'key'); 
     const props = {
-      appId: 'test-app-id',
-      apiKey: 'test-search-key',
+      searchClient: mockSearchClient,
       indexName: 'test-index-name',
       resultsState: {
         testResultStateData: 'test result state value'
       }
     };
     component.render(<AlgoliaInstantSearch {...props} />);
-
-    expect(algoliasearch).toHaveBeenCalledWith(props.appId, props.apiKey);
     expect(component.getRenderOutput()).toMatchSnapshot();
   });
 });

--- a/components/algolia-instant-search/algolia-instant-search.tsx
+++ b/components/algolia-instant-search/algolia-instant-search.tsx
@@ -1,22 +1,19 @@
 import React from 'react';
-import algoliasearch from 'algoliasearch';
+import { SearchClient } from 'algoliasearch';
 import { InstantSearch } from 'react-instantsearch-dom';
 import SearchResultList from '../algolia-search-result-list/algolia-search-result-list';
 
 interface AlgoliaInstantSearchProps {
   indexName: string;
   resultsState: unknown;
-  appId: string;
-  apiKey: string;
+  searchClient: SearchClient;
 }
 
 export default function AlgoliaInstantSearch({
   indexName,
   resultsState,
-  appId,
-  apiKey
+  searchClient
 }: AlgoliaInstantSearchProps): JSX.Element {
-  const searchClient = algoliasearch(appId, apiKey);
   return (
     <InstantSearch indexName={indexName} searchClient={searchClient} resultsState={resultsState}>
       <SearchResultList></SearchResultList>

--- a/components/algolia-search-result-list/algolia-search-result-list.tsx
+++ b/components/algolia-search-result-list/algolia-search-result-list.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connectStateResults } from 'react-instantsearch-dom';
 import BlogPost from '../../common/interfaces/blog-post.interface';
 import NoBlogPosts from '../blog-list/no-blog-posts';
+import LoadingBlogPosts from '../blog-list/loading-blog-posts';
 import HeroCard from '../hero-card/hero-card';
 import BlogList from '../blog-list/blog-list';
 
@@ -20,6 +21,9 @@ const flattenBlogPosts = (searchResults: SearchResults<BasicDoc>): BlogPost[] =>
 };
 
 const SearchResultList = connectStateResults(({ searchResults }) => {
+  if(!searchResults) {
+    return <LoadingBlogPosts />
+  }
   const blogPosts = flattenBlogPosts(searchResults);
   return blogPosts.length > 0 ? (
     <div id="searchResults">

--- a/components/blog-list/loading-blog-posts.tsx
+++ b/components/blog-list/loading-blog-posts.tsx
@@ -1,0 +1,21 @@
+import React, { ReactElement } from 'react';
+
+const LoadingBlogPosts = (): ReactElement => {
+  return (
+    <>
+      <div className="loading-blog-posts">
+        <p>Loading...</p>
+        <style jsx>{`
+          .loading-blog-posts {
+            padding-top: 60px;
+            display: flex;
+            justify-content: center;
+            min-height: 500px;
+          }
+        `}</style>
+      </div>
+    </>
+  );
+};
+
+export default LoadingBlogPosts;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18957,6 +18957,21 @@
         }
       }
     },
+    "swr": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-0.2.3.tgz",
+      "integrity": "sha512-JhuuD5ojqgjAQpZAhoPBd8Di0Mr1+ykByVKuRJdtKaxkUX/y8kMACWKkLgLQc8pcDOKEAnbIreNjU7HfqI9nHQ==",
+      "requires": {
+        "fast-deep-equal": "2.0.1"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        }
+      }
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "react-instantsearch-dom": "^6.6.0",
     "react-lazy-load-image-component": "^1.4.3",
     "react-markdown": "^4.3.1",
-    "react-syntax-highlighter": "^12.2.1"
+    "react-syntax-highlighter": "^12.2.1",
+    "swr": "^0.2.3"
   }
 }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Algolia search index data is loaded at build time


## What is the new behavior?
- the algolia index is loaded client-side

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information


