### PR TITLE
feat(blog page): loading linked blog pages dynamically

### DIFF
--- a/components/blog-card/__snapshots__/blog-card.spec.tsx.snap
+++ b/components/blog-card/__snapshots__/blog-card.spec.tsx.snap
@@ -5,9 +5,10 @@ exports[`BlogCard renders full blog card 1`] = `
   <section
     className="jsx-3551177564"
   >
-    <StaticLink
+    <NextLink
       ariaLabel="My First Blog Post"
-      href="/blog/my-first-blog"
+      as="/blog/my-first-blog"
+      href="/blog/[...slug]"
     >
       <t
         afterLoad={[Function]}
@@ -145,7 +146,7 @@ exports[`BlogCard renders full blog card 1`] = `
           </div>
         </article>
       </t>
-    </StaticLink>
+    </NextLink>
   </section>
   <JSXStyle
     dynamic={
@@ -178,8 +179,10 @@ exports[`BlogCard renders full blog card with lazy loaded placeholders 1`] = `
 >
   <a
     aria-label="My First Blog Post"
-    className="jsx-3354872520"
+    className="jsx-3574172415"
     href="/blog/my-first-blog"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
   >
     <div
       className="jsx-3551177564 article-placeholder"

--- a/components/blog-card/blog-card.tsx
+++ b/components/blog-card/blog-card.tsx
@@ -2,10 +2,10 @@ import React, { ReactElement } from 'react';
 import BlogPost from '../../common/interfaces/blog-post.interface';
 import theme from '../../common/styles/default/theme';
 import BlogCardMeta from '../blog-card-meta/blog-card-meta';
-import StaticLink from '../static-link/static-link';
 import { useRouter } from 'next/router';
 import Picture from '../picture/picture';
 import { LazyLoadComponent } from 'react-lazy-load-image-component';
+import NextLink from '../next-link/next-link';
 
 interface BlogCardProps {
   blogPost: BlogPost;
@@ -20,7 +20,7 @@ const BlogCard = ({ blogPost }: BlogCardProps): ReactElement => {
   return (
     <>
       <section>
-        <StaticLink ariaLabel={blogPost.title} href={blogLink}>
+        <NextLink href="/blog/[...slug]" as={blogLink} ariaLabel={blogPost.title}>
           <LazyLoadComponent placeholder={<div className="article-placeholder"></div>}>
             <article>
               <div className="blog-card-image">
@@ -81,7 +81,7 @@ const BlogCard = ({ blogPost }: BlogCardProps): ReactElement => {
               </div>
             </article>
           </LazyLoadComponent>
-        </StaticLink>
+        </NextLink>
       </section>
 
       <style jsx>{`

--- a/components/hero-card/__snapshots__/hero-card.spec.tsx.snap
+++ b/components/hero-card/__snapshots__/hero-card.spec.tsx.snap
@@ -8,8 +8,10 @@ exports[`HeroCard renders full hero card 1`] = `
 >
   <a
     aria-label="My First Blog Post"
-    className="jsx-3354872520"
+    className="jsx-3574172415"
     href="/blog/my-first-blog"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
   >
     <article
       className="jsx-2211547671"
@@ -111,8 +113,10 @@ exports[`HeroCard renders full hero card with vse query string in link for previ
 >
   <a
     aria-label="My First Blog Post"
-    className="jsx-3354872520"
+    className="jsx-3574172415"
     href="/preview?vse=test-vse.domain&content=8d6943c7-6028-4fac-b45e-57fc63bd032a"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
   >
     <article
       className="jsx-2211547671"

--- a/components/hero-card/hero-card.tsx
+++ b/components/hero-card/hero-card.tsx
@@ -2,9 +2,9 @@ import React, { ReactElement } from 'react';
 import BlogPost from '../../common/interfaces/blog-post.interface';
 import theme from '../../common/styles/default/theme';
 import BlogCardMeta from '../blog-card-meta/blog-card-meta';
-import StaticLink from '../static-link/static-link';
 import { useRouter } from 'next/router';
 import Picture from '../picture/picture';
+import NextLink from '../next-link/next-link';
 
 interface HeroCardProps {
   blogPost: BlogPost;
@@ -22,7 +22,7 @@ const HeroCard = ({ blogPost }: HeroCardProps): ReactElement => {
     return (
       <>
         <section>
-          <StaticLink ariaLabel={blogPost.title} href={blogLink}>
+          <NextLink href="/blog/[...slug]" as={blogLink} ariaLabel={blogPost.title}>
             <article>
               <div className="blog-card-image">
                 <Picture
@@ -72,7 +72,7 @@ const HeroCard = ({ blogPost }: HeroCardProps): ReactElement => {
                 <p>{blogPost.description}</p>
               </div>
             </article>
-          </StaticLink>
+          </NextLink>
         </section>
         <style jsx>{`
         section {

--- a/components/next-link/__snapshots__/next-link.spec.tsx.snap
+++ b/components/next-link/__snapshots__/next-link.spec.tsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NextLink renders next link as an anchor tag 1`] = `
+<a
+  aria-label=""
+  className="jsx-3574172415"
+  href="//href-link/a-test"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+>
+  <div
+    className="something-to-link"
+  />
+</a>
+`;
+
+exports[`NextLink renders next link as an anchor tag with aria-label 1`] = `
+<a
+  aria-label="link title"
+  className="jsx-3574172415"
+  href="//href-link/a-test"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+>
+  <div
+    className="something-to-link"
+  />
+</a>
+`;

--- a/components/next-link/next-link.spec.tsx
+++ b/components/next-link/next-link.spec.tsx
@@ -1,0 +1,34 @@
+/* eslint-env jest */
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import NextLink from './next-link';
+
+const mockUseRouter = jest.fn();
+jest.mock('next/router', () => {
+  return {
+    useRouter: () => mockUseRouter()
+  };
+});
+
+describe('NextLink', () => {
+  test('renders next link as an anchor tag', async () => {
+    mockUseRouter.mockImplementationOnce(() => ({ route: '/', query: {} }));
+    const component = await renderer.create(
+      <NextLink href="/href-link/[..test]" as="//href-link/a-test">
+        <div className="something-to-link"></div>
+      </NextLink>
+    );
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  test('renders next link as an anchor tag with aria-label', async () => {
+    mockUseRouter.mockImplementationOnce(() => ({ route: '/', query: {} }));
+    const component = await renderer.create(
+      <NextLink href="/href-link/[..test]" as="//href-link/a-test" ariaLabel="link title">
+        <div className="something-to-link"></div>
+      </NextLink>
+    );
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+});

--- a/components/next-link/next-link.tsx
+++ b/components/next-link/next-link.tsx
@@ -1,0 +1,29 @@
+import React, { ReactElement } from 'react';
+import Link from 'next/link';
+
+export interface StaticLinkProps {
+  children: JSX.Element;
+  href: string;
+  as: string;
+  ariaLabel?: string;
+}
+
+const NextLink = ({ children, href, as, ariaLabel = '' }: StaticLinkProps): ReactElement => {
+  return (
+    <>
+      <Link href={href} as={as}>
+        <a aria-label={ariaLabel}>
+          {children}
+          <style jsx>{`
+            a {
+              text-decoration: none;
+              display: flex;
+            }
+          `}</style>
+        </a>
+      </Link>
+    </>
+  );
+};
+
+export default NextLink;

--- a/components/next-link/next-link.tsx
+++ b/components/next-link/next-link.tsx
@@ -1,14 +1,14 @@
 import React, { ReactElement } from 'react';
 import Link from 'next/link';
 
-export interface StaticLinkProps {
+export interface NextLinkProps {
   children: JSX.Element;
   href: string;
   as: string;
   ariaLabel?: string;
 }
 
-const NextLink = ({ children, href, as, ariaLabel = '' }: StaticLinkProps): ReactElement => {
+const NextLink = ({ children, href, as, ariaLabel = '' }: NextLinkProps): ReactElement => {
   return (
     <>
       <Link href={href} as={as}>

--- a/next.config.js
+++ b/next.config.js
@@ -48,8 +48,8 @@ const exportPathMap = async function () {
       } else {
         const path = `/blog/${encodeURIComponent(blogPost.deliveryKey)}`;
         const pageInfo = {
-          page: '/blog',
-          query: { deliveryKey: blogPost.deliveryKey }
+          page: '/blog/[...slug]',
+          query: { slug: blogPost.deliveryKey }
         };
         console.info(`Loading blog post "${path}`, pageInfo);
         pages[path] = pageInfo;

--- a/pages/blog/[...slug].tsx
+++ b/pages/blog/[...slug].tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { NextPage } from 'next';
-import BlogPost from '../common/interfaces/blog-post.interface';
-import Layout from '../layouts/default';
-import { getBlogPostByDeliveryKey } from '../common/services/blog-post.service';
-import Microdata from '../components/microdata/microdata';
+import BlogPost from '../../common/interfaces/blog-post.interface';
+import Layout from '../../layouts/default';
+import { getBlogPostByDeliveryKey } from '../../common/services/blog-post.service';
+import Microdata from '../../components/microdata/microdata';
 import { NextSeo } from 'next-seo';
-import Blog from '../components/blog/blog';
-import SharePost from '../components/share-post/share-post';
+import Blog from '../../components/blog/blog';
+import SharePost from '../../components/share-post/share-post';
 import { Image } from 'dc-delivery-sdk-js';
-import { defaultClientConfig } from '../common/services/dynamic-content-client-config';
+import { defaultClientConfig } from '../../common/services/dynamic-content-client-config';
 import { NextPageContext } from 'next';
 
 interface BlogPostProps {
@@ -66,8 +66,9 @@ const BlogPostPage: NextPage<BlogPostProps> = ({ blogPost }: BlogPostProps) => {
 };
 
 BlogPostPage.getInitialProps = async ({ query }: NextPageContext) => {
-  const { vse, deliveryKey } = query;
+  const { vse, slug } = query;
   const stagingEnvironment = vse ? `//${vse.toString()}` : undefined;
+  const deliveryKey = slug && slug[0];
   if (typeof deliveryKey !== 'string') {
     throw new Error('Unable to generate BlogPostPage, missing deliveryKey');
   }

--- a/tests/next/next.config.spec.ts
+++ b/tests/next/next.config.spec.ts
@@ -45,9 +45,9 @@ describe('next.config.js', (): void => {
 
     expect(result).toEqual({
       '/blog/test-delivery-key': {
-        page: '/blog',
+        page: '/blog/[...slug]',
         query: {
-          deliveryKey: 'test-delivery-key'
+          slug: 'test-delivery-key'
         }
       },
       '/': {

--- a/tests/pages/blog.spec.tsx
+++ b/tests/pages/blog.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import React from 'react';
 import renderer from 'react-test-renderer';
-import BlogPostPage from '../../pages/blog';
+import BlogPostPage from '../../pages/blog/[...slug]';
 import blogPostFixture from '../fixtures/single-blog-post-data-object.json';
 import { getBlogPostByDeliveryKey } from '../../common/services/blog-post.service';
 import { NextPageContext } from 'next';
@@ -18,41 +18,45 @@ const mockGetBlogPostByDeliveryKey: jest.MockedFunction<typeof getBlogPostByDeli
 >;
 
 describe('Blog page', () => {
+  let blogPost;
+
   beforeEach(() => {
     process.env.DYNAMIC_CONTENT_REFERENCE_ID = 'reference-id';
     process.env.GA_TRACKING_ID = 'ga-tracking-id';
+    blogPost = { ...blogPostFixture };
+    blogPost._meta.toJSON = () => ({});
     jest.clearAllMocks();
   });
 
   test('renders Blog page with content', () => {
-    const component = renderer.create(<BlogPostPage blogPost={blogPostFixture} />);
+    const component = renderer.create(<BlogPostPage blogPost={blogPost} />);
     expect(component.toJSON()).toMatchSnapshot();
   });
 
   test('getInitialProps returns blog post content via api', async () => {
-    mockGetBlogPostByDeliveryKey.mockResolvedValue(blogPostFixture);
-    const query = { deliveryKey: 'blog-id' };
-    const result = await BlogPostPage.getInitialProps({ query, pathname: '/blog' } as unknown as NextPageContext);
+    mockGetBlogPostByDeliveryKey.mockResolvedValue(blogPost);
+    const query = { slug: ['blog-slug'] };
+    const result = await BlogPostPage.getInitialProps(({ query } as unknown) as NextPageContext);
     expect(result).toEqual({ blogPost: blogPostFixture });
   });
 
   test('getInitialProps should call getHydratedBlogList with staging environment', async () => {
-    mockGetBlogPostByDeliveryKey.mockResolvedValue(blogPostFixture);
-    const query = { deliveryKey: 'blog-id', vse: 'vse-base-url' };
-    await BlogPostPage.getInitialProps({ query, pathname: '/blog' } as unknown as NextPageContext);
-    expect(mockGetBlogPostByDeliveryKey).toHaveBeenCalledWith(query.deliveryKey, `//${query.vse}`);
+    mockGetBlogPostByDeliveryKey.mockResolvedValue(blogPost);
+    const query = { vse: 'vse-base-url', slug: ['blog-slug'] };
+    await BlogPostPage.getInitialProps(({ query } as unknown) as NextPageContext);
+    expect(mockGetBlogPostByDeliveryKey).toHaveBeenCalledWith('blog-slug', `//${query.vse}`);
   });
 
   test('getInitialProps should call getHydratedBlogList without staging environment', async () => {
-    mockGetBlogPostByDeliveryKey.mockResolvedValue(blogPostFixture);
-    const query = { deliveryKey: 'blog-id' };
-    await BlogPostPage.getInitialProps({ query, pathname: '/blog' } as unknown as NextPageContext);
-    expect(mockGetBlogPostByDeliveryKey).toHaveBeenCalledWith(query.deliveryKey, undefined);
+    mockGetBlogPostByDeliveryKey.mockResolvedValue(blogPost);
+    const query = { slug: ['blog-slug'] };
+    await BlogPostPage.getInitialProps(({ query } as unknown) as NextPageContext);
+    expect(mockGetBlogPostByDeliveryKey).toHaveBeenCalledWith('blog-slug', undefined);
   });
 
   test('getInitialProps throws error when deliveryKey is undefined', async () => {
     mockGetBlogPostByDeliveryKey.mockRejectedValue(new Error());
     const query = {};
-    await expect(BlogPostPage.getInitialProps({ query, pathname: '/blog' } as unknown as NextPageContext)).rejects.toThrowError(Error);
+    await expect(BlogPostPage.getInitialProps(({ query } as unknown) as NextPageContext)).rejects.toThrowError(Error);
   });
 });


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
When clicking a link on the blog list page we only link to the static version.

## What is the new behavior?
There is a period of time when the search index will contain a newly published blog post but the static page will not have been built.  Links on the blog post page now loads a dynamic version of the blog post to avoid 404's should the page not have not been built.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


