### PR TITLE
fix(keyword search): added the default refinement to the sortby

### DIFF
--- a/components/search-result-list/__snapshots__/sort-by-dropdown.spec.tsx.snap
+++ b/components/search-result-list/__snapshots__/sort-by-dropdown.spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`SortByDropdown should render LoadingBlogPosts when searchResults is und
     </span>
     <ConnectorWrapper
       className="container-option"
-      defaultRefinement="instant_search"
+      defaultRefinement="indexName"
       items={
         Array [
           Object {

--- a/components/search-result-list/sort-by-dropdown.tsx
+++ b/components/search-result-list/sort-by-dropdown.tsx
@@ -11,7 +11,7 @@ const SortByDropdown = (): ReactElement => {
         <span>Sort by</span>
         <SortBy
           className="container-option"
-          defaultRefinement="instant_search"
+          defaultRefinement={indexName}
           items={[
             {
               label: 'Sort by date (ascending)',


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
search is broken until you select a sort by

## What is the new behavior?
- defaults the initial sortby to be the primary index

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information


