### PR TITLE
fix(sort by): fixed alignment in chrome & safari

### DIFF
--- a/components/search-result-list/__snapshots__/sort-by-dropdown.spec.tsx.snap
+++ b/components/search-result-list/__snapshots__/sort-by-dropdown.spec.tsx.snap
@@ -3,10 +3,10 @@
 exports[`SortByDropdown should render LoadingBlogPosts when searchResults is undefined 1`] = `
 <React.Fragment>
   <div
-    className="jsx-3817679898 sort-by-container"
+    className="jsx-3184742088 sort-by-container"
   >
     <span
-      className="jsx-3817679898"
+      className="jsx-3184742088"
     >
       Sort by
     </span>
@@ -45,9 +45,9 @@ exports[`SortByDropdown should render LoadingBlogPosts when searchResults is und
         "500",
       ]
     }
-    id="466742199"
+    id="4049161898"
   >
-    div.sort-by-container.__jsx-style-dynamic-selector{margin:auto;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;margin-top:20px;-webkit-box-pack:right;-webkit-justify-content:right;-ms-flex-pack:right;justify-content:right;-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;max-width:1097px;padding-right:40px;}div.sort-by-container.__jsx-style-dynamic-selector&gt;span.__jsx-style-dynamic-selector{padding-right:15px;font-size:1.125rem;font-weight:400;}select.ais-SortBy-select{color:#333;font-size:1.125rem;font-weight:500;background-color:#f2f2f2;padding:5px 30px 5px 5px;-webkit-appearance:none;-moz-appearance:none;appearance:none;border:none;}div.ais-SortBy{position:relative;}div.ais-SortBy:after{color:#333;content:'▾';right:15px;top:6px;position:absolute;pointer-events:none;}
+    div.sort-by-container.__jsx-style-dynamic-selector{margin:auto;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;margin-top:20px;-webkit-box-pack:end;-webkit-justify-content:flex-end;-ms-flex-pack:end;justify-content:flex-end;-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;max-width:1097px;padding-right:40px;}div.sort-by-container.__jsx-style-dynamic-selector&gt;span.__jsx-style-dynamic-selector{padding-right:15px;font-size:1.125rem;font-weight:400;}select.ais-SortBy-select{color:#333;font-size:1.125rem;font-weight:500;background-color:#f2f2f2;padding:5px 30px 5px 5px;-webkit-appearance:none;-moz-appearance:none;appearance:none;border:none;}div.ais-SortBy{position:relative;}div.ais-SortBy:after{color:#333;content:'▾';right:15px;top:6px;position:absolute;pointer-events:none;}
   </JSXStyle>
 </React.Fragment>
 `;

--- a/components/search-result-list/sort-by-dropdown.tsx
+++ b/components/search-result-list/sort-by-dropdown.tsx
@@ -38,7 +38,7 @@ const SortByDropdown = (): ReactElement => {
           margin: auto;
           display: flex;
           margin-top: 20px;
-          justify-content: right;
+          justify-content: flex-end;
           align-items: center;
           max-width: ${theme.layout.widePageWidth};
           padding-right: 40px;


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Chrome & Safari don't support "justify-content: right;" so the sort-by is left aligned in Chrome & Safari

## What is the new behavior?
- swapped to use flex-end to right align the sort-by drop down

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information


