### PR TITLE
fix(pagination): scroll to top of page when pagination link clicked

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ import HeroBanner from '../components/hero-banner/hero-banner';
 import Layout from '../layouts/default';
 import useSWR from 'swr';
 import { Blog } from '../common/interfaces/blog.interface';
-import { InstantSearch, Configure } from 'react-instantsearch-dom';
+import { InstantSearch, Configure, ScrollTo } from 'react-instantsearch-dom';
 import SearchResultList from '../components/search-result-list/search-result-list';
 import HeaderSearchBox from '../components/header-search-box/header-search-box';
 import SearchResultPagination from '../components/search-result-pagination/search-result-pagination';
@@ -47,6 +47,7 @@ const Index: NextPage<IndexProps> = ({ title, heading, searchPlaceHolder, buildT
         resultsState={runtimeResultState || buildTimeResultState}
       >
         <Configure hitsPerPage={10} />
+        <ScrollTo scrollOn="page" />
         <HeroBanner heading={heading}>
           <HeaderSearchBox placeholderText={searchPlaceHolder} />
         </HeroBanner>

--- a/tests/pages/__snapshots__/index.spec.tsx.snap
+++ b/tests/pages/__snapshots__/index.spec.tsx.snap
@@ -117,6 +117,9 @@ exports[`Index components should render index 1`] = `
     <ConnectorWrapper
       hitsPerPage={10}
     />
+    <ConnectorWrapper
+      scrollOn="page"
+    />
     <HeroBanner
       heading="heading"
     >


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
View remains at the bottom on the blog list when a pagination link is clicked


## What is the new behavior?
View scrolls to the top of the list then a pagination link is clicked


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

