### PR TITLE
fix(preview): checking for vse via router aspath to construct next links for preview

### DIFF
--- a/components/blog-card/blog-card.spec.tsx
+++ b/components/blog-card/blog-card.spec.tsx
@@ -24,7 +24,7 @@ jest.mock('react-instantsearch-dom', () => ({
 describe('BlogCard', () => {
   test('renders full blog card', () => {
     mockUseRouter.mockImplementationOnce(() => {
-      return { query: {} };
+      return { asPath: '' };
     });
 
     const component = ShallowRenderer.createRenderer();
@@ -34,7 +34,7 @@ describe('BlogCard', () => {
 
   test('renders full blog card with lazy loaded placeholders', () => {
     mockUseRouter.mockImplementationOnce(() => {
-      return { query: {} };
+      return { asPath: '' };
     });
     const component = renderer.create(<BlogCard blogPost={blogPostFixture} />);
     expect(component.toJSON()).toMatchSnapshot();
@@ -43,7 +43,7 @@ describe('BlogCard', () => {
   test('renders full blog card with vse query string in link for preview', () => {
     mockUseRouter.mockImplementationOnce(() => {
       return {
-        query: { vse: 'test-vse.domain' }
+        asPath: '/?vse=test-vse.domain'
       };
     });
 

--- a/components/blog-card/blog-card.tsx
+++ b/components/blog-card/blog-card.tsx
@@ -7,6 +7,7 @@ import Picture from '../picture/picture';
 import { LazyLoadComponent } from 'react-lazy-load-image-component';
 import NextLink from '../next-link/next-link';
 import { Highlight } from 'react-instantsearch-dom';
+import qs from 'qs';
 
 interface BlogCardProps {
   blogPost: BlogPost;
@@ -14,14 +15,15 @@ interface BlogCardProps {
 
 const BlogCard = ({ blogPost }: BlogCardProps): ReactElement => {
   const router = useRouter();
-  const vse = router.query.vse ? router.query.vse.toString() : '';
+  const parsedQueryString = qs.parse(router.asPath.substring(router.asPath.indexOf('?') + 1));
+  const { vse } = parsedQueryString;
   const routerQuery = vse ? `?vse=${vse}&content=${blogPost._meta.deliveryId}` : '';
   const path = vse ? '/preview' : `/blog/${encodeURIComponent((blogPost._meta.deliveryKey || '').toLowerCase())}`;
-  const blogLink = `${path}${routerQuery}`;
+  const blogHref = vse ? '/preview' : '/blog/[...slug]';
   return (
     <>
       <section>
-        <NextLink href="/blog/[...slug]" as={blogLink} ariaLabel={blogPost.title}>
+        <NextLink href={blogHref} as={`${path}${routerQuery}`} ariaLabel={blogPost.title}>
           <LazyLoadComponent placeholder={<div className="article-placeholder"></div>}>
             <article>
               <div className="blog-card-image">

--- a/components/hero-card/__snapshots__/hero-card.spec.tsx.snap
+++ b/components/hero-card/__snapshots__/hero-card.spec.tsx.snap
@@ -491,7 +491,7 @@ exports[`HeroCard renders full hero card with vse query string in link for previ
     <NextLink
       ariaLabel="My First Blog Post"
       as="/preview?vse=test-vse.domain&content=8d6943c7-6028-4fac-b45e-57fc63bd032a"
-      href="/blog/[...slug]"
+      href="/preview"
     >
       <article
         className="jsx-3076843137"

--- a/components/hero-card/hero-card.spec.tsx
+++ b/components/hero-card/hero-card.spec.tsx
@@ -20,11 +20,10 @@ jest.mock('react-instantsearch-dom', () => ({
   }
 }));
 
-
 describe('HeroCard', () => {
   test('renders full hero card', async () => {
     mockUseRouter.mockImplementationOnce(() => {
-      return { query: {} };
+      return { asPath: '' };
     });
     const component = ShallowRenderer.createRenderer();
     component.render(<HeroCard blogPost={blogPostFixture} />);
@@ -33,7 +32,7 @@ describe('HeroCard', () => {
 
   test('renders full hero card with vse query string in link for preview', async () => {
     mockUseRouter.mockImplementationOnce(() => {
-      return { query: { vse: 'test-vse.domain' } };
+      return { asPath: '?vse=test-vse.domain' };
     });
     const component = ShallowRenderer.createRenderer();
     component.render(<HeroCard blogPost={blogPostFixture} />);

--- a/components/hero-card/hero-card.tsx
+++ b/components/hero-card/hero-card.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router';
 import Picture from '../picture/picture';
 import { Highlight } from 'react-instantsearch-dom';
 import NextLink from '../next-link/next-link';
+import qs from 'qs';
 
 interface HeroCardProps {
   blogPost: BlogPost;
@@ -16,14 +17,16 @@ const HeroCard = ({ blogPost }: HeroCardProps): ReactElement => {
     return <div />;
   } else {
     const router = useRouter();
-    const { vse } = router.query;
+    const parsedQueryString = qs.parse(router.asPath.substring(router.asPath.indexOf('?') + 1));
+    const { vse } = parsedQueryString;
     const routerQuery = vse ? `?vse=${vse}&content=${blogPost._meta.deliveryId}` : '';
     const path = vse ? '/preview' : `/blog/${encodeURIComponent((blogPost._meta.deliveryKey || '').toLowerCase())}`;
-    const blogLink = `${path}${routerQuery}`;
+    const blogHref = vse ? '/preview' : '/blog/[...slug]';
+
     return (
       <>
         <section>
-          <NextLink href="/blog/[...slug]" as={blogLink} ariaLabel={blogPost.title}>
+          <NextLink href={blogHref} as={`${path}${routerQuery}`} ariaLabel={blogPost.title}>
             <article>
               <div className="blog-card-image">
                 <Picture
@@ -72,7 +75,9 @@ const HeroCard = ({ blogPost }: HeroCardProps): ReactElement => {
                   <Highlight hit={blogPost} attribute="title" tagName="mark" />
                 </h1>
                 <BlogCardMeta authors={blogPost.authors} publishedDate={blogPost.date} readTime={blogPost.readTime} />
-                <p><Highlight hit={blogPost} attribute="description" tagName="mark" /></p>
+                <p>
+                  <Highlight hit={blogPost} attribute="description" tagName="mark" />
+                </p>
               </div>
             </article>
           </NextLink>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -22,7 +22,7 @@ interface IndexProps extends Blog {
 }
 
 const sanitizeStateParams = (state: SearchState) => {
-  const acceptedKeys = ['page', 'query', 'sortBy', 'menu'];
+  const acceptedKeys = ['page', 'query', 'sortBy', 'menu', 'vse'];
   return Object.keys(state).reduce((r: SearchState, s) => {
     if (acceptedKeys.includes(s)) {
       r[s] = state[s];

--- a/pages/preview.tsx
+++ b/pages/preview.tsx
@@ -3,11 +3,14 @@ import Layout from '../layouts/default';
 import Visualization from '../components/visualization/visualization';
 import { useRouter } from 'next/router';
 import { NextSeo } from 'next-seo';
+import qs from 'qs';
 
 const PreviewPage = (): ReactElement => {
   const router = useRouter();
-  const stagingEnvironment = router.query.vse ? router.query.vse.toString() : '';
-  const contentItemId = router.query.content ? router.query.content.toString() : '';
+  const parsedQueryString = qs.parse(router.asPath.substring(router.asPath.indexOf('?') + 1));
+  const stagingEnvironment: string = parsedQueryString.vse as string;
+  const contentItemId: string = parsedQueryString.content as string;
+
   return (
     <>
       <NextSeo noindex={true} />


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Preview links failed to work due to the vse query prop being empty at runtime


## What is the new behavior?
Switched to use router asPath value to get correct runtime vse params

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


