### PR TITLE
fix(blog post): updating build process and blog links to fallback to object id on missing key

### DIFF
--- a/common/services/blog-post.service.ts
+++ b/common/services/blog-post.service.ts
@@ -59,3 +59,14 @@ export async function getBlogPostByDeliveryKey(key: string, stagingEnvironment?:
   }
   return await parseBlogPost(contentItem);
 }
+
+export async function getBlogPostByDeliveryId(id: string, stagingEnvironment?: string): Promise<BlogPost> {
+  const clientConfig = { ...defaultClientConfig, baseUrl: process.env.DYNAMIC_CONTENT_BASE_URL, stagingEnvironment };
+
+  const deliveryClient = new DynamicContentDeliveryService(clientConfig);
+  const contentItem = (await deliveryClient.getContentItemById(id)).toJSON();
+  if (!isBlogPost(contentItem)) {
+    throw new Error('Content Item is not a Blog Post');
+  }
+  return await parseBlogPost(contentItem);
+}

--- a/components/blog-card/blog-card.tsx
+++ b/components/blog-card/blog-card.tsx
@@ -19,8 +19,12 @@ const BlogCard = ({ blogPost }: BlogCardProps): ReactElement => {
   const parsedQueryString = qs.parse(router.asPath.substring(router.asPath.indexOf('?') + 1));
   const { vse } = parsedQueryString;
   const routerQuery = vse ? `?vse=${vse}&content=${blogPost._meta.deliveryId}` : '';
-  const path = vse ? '/preview' : `/blog/${encodeURIComponent((blogPost._meta.deliveryKey || '').toLowerCase())}`;
+
+  const path = vse
+    ? '/preview'
+    : `/blog/${encodeURIComponent((blogPost._meta.deliveryKey || blogPost._meta.deliveryId).toLowerCase())}`;
   const blogHref = vse ? '/preview' : '/blog/[...slug]';
+
   return (
     <>
       <section>

--- a/components/hero-card/hero-card.tsx
+++ b/components/hero-card/hero-card.tsx
@@ -21,7 +21,9 @@ const HeroCard = ({ blogPost }: HeroCardProps): ReactElement => {
     const parsedQueryString = qs.parse(router.asPath.substring(router.asPath.indexOf('?') + 1));
     const { vse } = parsedQueryString;
     const routerQuery = vse ? `?vse=${vse}&content=${blogPost._meta.deliveryId}` : '';
-    const path = vse ? '/preview' : `/blog/${encodeURIComponent((blogPost._meta.deliveryKey || '').toLowerCase())}`;
+    const path = vse
+      ? '/preview'
+      : `/blog/${encodeURIComponent((blogPost._meta.deliveryKey || blogPost._meta.deliveryId).toLowerCase())}`;
     const blogHref = vse ? '/preview' : '/blog/[...slug]';
 
     return (

--- a/next.config.js
+++ b/next.config.js
@@ -43,7 +43,6 @@ const exportPathMap = async function () {
     });
 
     results.hits.forEach(blogPost => {
-      console.log(blogPost);
       if (!blogPost.deliveryKey) {
         console.warn('No deliveryKey for blogPost', blogPost);
       }

--- a/next.config.js
+++ b/next.config.js
@@ -43,17 +43,18 @@ const exportPathMap = async function () {
     });
 
     results.hits.forEach(blogPost => {
+      console.log(blogPost);
       if (!blogPost.deliveryKey) {
         console.warn('No deliveryKey for blogPost', blogPost);
-      } else {
-        const path = `/blog/${encodeURIComponent(blogPost.deliveryKey)}`;
-        const pageInfo = {
-          page: '/blog/[...slug]',
-          query: { slug: blogPost.deliveryKey }
-        };
-        console.info(`Loading blog post "${path}`, pageInfo);
-        pages[path] = pageInfo;
       }
+      const slug = blogPost.deliveryKey ? blogPost.deliveryKey : blogPost.objectID;
+      const path = `/blog/${encodeURIComponent(slug)}`;
+      const pageInfo = {
+        page: '/blog/[...slug]',
+        query: { slug }
+      };
+      console.info(`Loading blog post "${path}`, pageInfo);
+      pages[path] = pageInfo;
     });
   } catch (err) {
     console.error('Error building exportPathMap', err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3642,6 +3642,11 @@
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
     },
+    "@types/uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-xSQfNcvOiE5f9dyd4Kzxbof1aTrLobL278pGLKOZI6esGfZ7ts9Ka16CzIN6Y8hFHE1C7jIBZokULhK1bOgjRw=="
+    },
     "@types/yargs": {
       "version": "15.0.5",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
@@ -20003,6 +20008,22 @@
       "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
       "dev": true,
       "optional": true
+    },
+    "uuidv4": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.1.1.tgz",
+      "integrity": "sha512-ZplGb1SHFMVH3l7PUQl2Uwo+FpJQV6IPOoU+MjjbqrNYQolqbGwv+/sn9F+AGMsMOgGz3r9JN3ztGUi0VzMxmw==",
+      "requires": {
+        "@types/uuid": "8.0.0",
+        "uuid": "8.2.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
+          "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
+        }
+      }
     },
     "v8-compile-cache": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "react-lazy-load-image-component": "^1.4.3",
     "react-markdown": "^4.3.1",
     "react-syntax-highlighter": "^12.2.1",
-    "swr": "^0.2.3"
+    "swr": "^0.2.3",
+    "uuidv4": "^6.1.1"
   }
 }

--- a/pages/blog/[...slug].tsx
+++ b/pages/blog/[...slug].tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { NextPage } from 'next';
 import BlogPost from '../../common/interfaces/blog-post.interface';
 import Layout from '../../layouts/default';
-import { getBlogPostByDeliveryKey } from '../../common/services/blog-post.service';
+import { getBlogPostByDeliveryKey, getBlogPostByDeliveryId } from '../../common/services/blog-post.service';
 import Microdata from '../../components/microdata/microdata';
 import { NextSeo } from 'next-seo';
 import Blog from '../../components/blog/blog';
@@ -10,6 +10,7 @@ import SharePost from '../../components/share-post/share-post';
 import { Image } from 'dc-delivery-sdk-js';
 import { defaultClientConfig } from '../../common/services/dynamic-content-client-config';
 import { NextPageContext } from 'next';
+import { isUuid } from 'uuidv4';
 import TagChips from '../../components/tag-chips/tag-chips';
 
 interface BlogPostProps {
@@ -75,11 +76,13 @@ const BlogPostPage: NextPage<BlogPostProps> = ({ blogPost }: BlogPostProps) => {
 BlogPostPage.getInitialProps = async ({ query }: NextPageContext) => {
   const { vse, slug } = query;
   const stagingEnvironment = vse ? `//${vse.toString()}` : undefined;
-  const deliveryKey = slug && slug[0];
-  if (typeof deliveryKey !== 'string') {
+  const deliverySlug = slug && slug[0];
+  if (typeof deliverySlug !== 'string') {
     throw new Error('Unable to generate BlogPostPage, missing deliveryKey');
   }
-  const blogPost = await getBlogPostByDeliveryKey(deliveryKey, stagingEnvironment);
+  const blogPost = isUuid(deliverySlug)
+    ? await getBlogPostByDeliveryId(deliverySlug, stagingEnvironment)
+    : await getBlogPostByDeliveryKey(deliverySlug, stagingEnvironment);
   return { blogPost };
 };
 

--- a/tests/next/next.config.spec.ts
+++ b/tests/next/next.config.spec.ts
@@ -73,7 +73,7 @@ describe('next.config.js', (): void => {
     });
   });
 
-  test('exportPathMap should return landing page and omit any blog posts that do not have a delivery key is not set', async (): Promise<
+  test('exportPathMap should return landing page and use delivery id if any blog posts do not have a delivery key set', async (): Promise<
     void
   > => {
     mockSearch.mockImplementationOnce(() => {
@@ -96,6 +96,12 @@ describe('next.config.js', (): void => {
         query: {
           content: '',
           vse: ''
+        }
+      },
+      '/blog/test-object-id': {
+        page: '/blog/[...slug]',
+        query: {
+          slug: 'test-object-id'
         }
       },
       '/visualization.html': {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
The build process was discarding pages that did not have a delivery key.  Since we are now using a search index this leads to broken blog page links on the home page.


## What is the new behavior?
The build process now warns that a delivery key is missing but provides a blog page fallback based on delivery id so that we never have dead links.  Hero and blog card links have been updated to switch depending on which slug has been provided.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

