### PR TITLE
feat(schemas): add delivery key to the content form to enable validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ How to create a blog content item for your blog:
 2. Select the repo where you have registered "blog.json"
 3. Click "Create content"
 4. Select the "Blog" (or whatever label to assigned to the "blog.json" content type)
-5. Enter a title and a subtitle (these will appear on your blog)
+5. Enter a title, heading and search placeholder (these will appear on your blog)
+6. Enter a delivery key, e.g. "blog", this value will be used later on to retrieve the blog during the build process
 6. Click "Save"
-7. Click on the "Save" drop down menu, select "Delivery Key" and enter "blog" (you may enter another value if you wish), this value will be used later on to retrieve this blog post during the build phase.
 
 ### Creating a search index for your blog-post's
 

--- a/schemas/blog-post.json
+++ b/schemas/blog-post.json
@@ -23,7 +23,7 @@
         "deliveryKey":{
           "type":"string",
           "title":"Delivery key",
-          "description": "The delivery key is used as the URL slugt"
+          "description": "The delivery key is used as the URL slug"
         }
       },
       "required": ["deliveryKey"]

--- a/schemas/blog-post.json
+++ b/schemas/blog-post.json
@@ -17,6 +17,17 @@
       "minLength": 1,
       "maxLength": 150
     },
+    "_meta":{
+      "type":"object",
+      "properties":{
+        "deliveryKey":{
+          "type":"string",
+          "title":"Delivery key",
+          "description": "The delivery key is used as the URL slugt"
+        }
+      },
+      "required": ["deliveryKey"]
+    }, 
     "date": {
       "title": "Creation date",
       "description": "Creation date (YYYY-MM-DD)",
@@ -115,6 +126,6 @@
       }
     }
   },
-  "propertyOrder": ["title", "authors", "date", "description", "image", "tags", "readTime", "content"],
+  "propertyOrder": ["title", "_meta", "authors", "date", "description", "image", "tags", "readTime", "content"],
   "required": ["title", "authors", "date", "description", "image", "readTime", "content"]
 }

--- a/schemas/blog.json
+++ b/schemas/blog.json
@@ -33,8 +33,20 @@
       "minLength": 0,
       "maxLength": 150,
       "examples": ["Search for articles and topics"]
+    },
+    "_meta":{
+      "type":"object",
+      "properties":{
+        "deliveryKey":{
+          "type":"string",
+          "title":"Delivery key",
+          "description": "The delivery key will be used to retrieve the blog when it is built",
+          "examples": ["blog"]
+        }
+      },
+      "required": ["deliveryKey"]
     }
   },
   "required": ["title", "heading", "searchPlaceHolder"],
-  "propertyOrder": ["title", "heading", "searchPlaceHolder"]
+  "propertyOrder": ["title", "heading", "searchPlaceHolder","_meta"]
 }


### PR DESCRIPTION
Adds delivery key to blog.json and blog-post.json so that it appears in the content form as a
required field
* Delivery key should be editable from the content form
* Delivery key should be a required field when saving the blog content item
* Delivery key should be a required field when saving a blog post content item

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Delivery key has to be added from the action menu. Content items can be saved without a deliveryKey, which can cause build errors.


## What is the new behavior?
- Delivery key can be added in the content form. 
- Delivery key is a required field, avoiding errors.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR -->

