### PR TITLE
docs(readme): reverted the URL for previewing the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ If you used the dc-cli tool to register your content types, they will already ha
 
 ### How to configure Preview
 
-The Preview application URL should be the domain with the path of `/preview/?vse={{vse.domain}}`, e.g.: `https://blog.example.com/preview/?vse={{vse.domain}}`.
+The Preview application URL should be the domain with the path of `/?vse={{vse.domain}}`, e.g.: `https://blog.example.com/?vse={{vse.domain}}`.
 
 Notes:
 
@@ -295,7 +295,7 @@ After all of that we now have everything setup and you are ready to start writin
 3. Proceed to fill out the form, you can click on the "( + )" icons to include other content items
 4. Once done, click "Save"
 5. Next we need to define the "Delivery Key" for this content item, this will become the URL path/slug (e.g. /blog/hello-and-welcome-to-our-new-blog)
-6. You can preview your blog post via the visualisation icon (the eye) in the toolbar.
+6. You can preview your blog post via the visualization icon (the eye) in the toolbar.
 7. Once you're happy, go ahead an publish.
 
 # Publishing


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
The preview URL in the readme is specified as `/preview/?vse=abc.vse`


## What is the new behavior?
This has been reverted to the correct URL of `/?vse=abc.vse`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

