### PR TITLE
fix(header facet bar): adding media query styles to facet bar for smaller devices

### DIFF
--- a/components/clear-refinements/clear-refinements.spec.tsx
+++ b/components/clear-refinements/clear-refinements.spec.tsx
@@ -12,7 +12,7 @@ describe('ClearRefinements component', () => {
     const component = renderer.create(<ClearRefinements />).toJSON();
     expect(component).toMatchInlineSnapshot(`
       <button
-        className="jsx-2901729026"
+        className="jsx-3340861473"
         disabled={true}
         onClick={[Function]}
       >

--- a/components/clear-refinements/clear-refinements.tsx
+++ b/components/clear-refinements/clear-refinements.tsx
@@ -29,6 +29,18 @@ const ClearRefinements = ({ items, refine }: CurrentRefinementsProvided): ReactE
         border-radius: 5px;
         border: none;
         padding: 10px 14px;
+        white-space: nowrap;
+      }
+
+      @media (max-width: ${theme.layout.narrowPageWidth}) {
+        select {
+          width: 220px;
+          margin-right: 0;
+        }
+
+        button {
+          margin-top: 6px;
+        }
       }
     `}</style>
   </>

--- a/components/header-facet-bar/__snapshots__/header-facet-bar.spec.tsx.snap
+++ b/components/header-facet-bar/__snapshots__/header-facet-bar.spec.tsx.snap
@@ -3,42 +3,51 @@
 exports[`HeaderFaceBar component should render author and tags facet menus with a clear button 1`] = `
 <React.Fragment>
   <div
-    className="jsx-3417640431"
+    className="jsx-3003161143"
     id="FacetBar"
   >
     <h3
-      className="jsx-3417640431"
+      className="jsx-3003161143"
     >
       Show blogs by
     </h3>
-    <React.Fragment>
+    <div
+      className="jsx-3003161143 filter-container"
+    >
       <img
         alt="Authors"
-        className="jsx-3417640431"
+        className="jsx-3003161143"
         src="/static/images/ic-person.svg"
       />
       <ConnectorWrapper
         attribute="authors"
       />
-    </React.Fragment>
-    <React.Fragment>
+    </div>
+    <div
+      className="jsx-3003161143 filter-container"
+    >
       <img
         alt="Tags"
-        className="jsx-3417640431"
+        className="jsx-3003161143"
         src="/static/images/ic-tag.svg"
       />
       <ConnectorWrapper
         attribute="tags"
       />
-    </React.Fragment>
+    </div>
     <ConnectorWrapper
       clearsQuery={true}
     />
   </div>
   <JSXStyle
-    id="3417640431"
+    dynamic={
+      Array [
+        "736px",
+      ]
+    }
+    id="3582219113"
   >
-    #FacetBar.jsx-3417640431{width:100%;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-pack:center;-webkit-justify-content:center;-ms-flex-pack:center;justify-content:center;-webkit-flex-direction:row;-ms-flex-direction:row;flex-direction:row;text-align:center;-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;}h3.jsx-3417640431{font-size:16px;color:#999;font-weight:400;padding-right:20px;}img.jsx-3417640431{height:40px;width:40px;padding-right:10px;fill:#a7aaaf;}
+    #FacetBar.__jsx-style-dynamic-selector{width:100%;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-pack:center;-webkit-justify-content:center;-ms-flex-pack:center;justify-content:center;-webkit-flex-direction:row;-ms-flex-direction:row;flex-direction:row;text-align:center;-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;}h3.__jsx-style-dynamic-selector{font-size:16px;color:#999;font-weight:400;padding-right:20px;white-space:nowrap;}img.__jsx-style-dynamic-selector{height:40px;width:40px;padding-right:10px;fill:#a7aaaf;}.filter-container.__jsx-style-dynamic-selector{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}@media (max-width:736px){#FacetBar.__jsx-style-dynamic-selector{-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;}h3.__jsx-style-dynamic-selector{margin-bottom:2px;padding-right:0;}.filter-container.__jsx-style-dynamic-selector{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}}
   </JSXStyle>
 </React.Fragment>
 `;

--- a/components/header-facet-bar/header-facet-bar.tsx
+++ b/components/header-facet-bar/header-facet-bar.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import ClearRefinements from '../clear-refinements/clear-refinements';
 import MenuSelect from '../menu-select/menu-select';
+import theme from '../../common/styles/default/theme';
 
 interface HeaderFacetAttributes {
   authors: string;
@@ -17,16 +18,16 @@ const HeaderFacetBar = ({ authors, tags }: HeaderFacetAttributes): ReactElement 
       <div id="FacetBar">
         <h3>Show blogs by</h3>
         {authors && (
-          <>
+          <div className="filter-container">
             <img src="/static/images/ic-person.svg" alt="Authors" />
             <MenuSelect attribute={authors} />
-          </>
+          </div>
         )}
         {tags && (
-          <>
+          <div className="filter-container">
             <img src="/static/images/ic-tag.svg" alt="Tags" />
             <MenuSelect attribute={tags} />
-          </>
+          </div>
         )}
         <ClearRefinements clearsQuery />
       </div>
@@ -46,6 +47,7 @@ const HeaderFacetBar = ({ authors, tags }: HeaderFacetAttributes): ReactElement 
             color: #999;
             font-weight: 400;
             padding-right: 20px;
+            white-space: nowrap;
           }
 
           img {
@@ -53,6 +55,23 @@ const HeaderFacetBar = ({ authors, tags }: HeaderFacetAttributes): ReactElement 
             width: 40px;
             padding-right: 10px;
             fill: #a7aaaf;
+          }
+
+          .filter-container {
+            display: flex;
+          }
+
+          @media (max-width: ${theme.layout.narrowPageWidth}) {
+            #FacetBar {
+              flex-direction: column;
+            }
+            h3 {
+              margin-bottom: 2px;
+              padding-right: 0;
+            }
+            .filter-container {
+              display: flex;
+            }
           }
         `}
       </style>

--- a/components/menu-select/menu-select.spec.tsx
+++ b/components/menu-select/menu-select.spec.tsx
@@ -20,18 +20,18 @@ describe('MenuSelect component', () => {
     const component = renderer.create(<MenuSelect attribute="testValue" />).toJSON();
     expect(component).toMatchInlineSnapshot(`
       <select
-        className="jsx-2370241207 "
+        className="jsx-840549149 "
         onChange={[Function]}
         value=""
       >
         <option
-          className="jsx-2370241207"
+          className="jsx-840549149"
           value=""
         >
           See all options
         </option>
         <option
-          className="jsx-2370241207"
+          className="jsx-840549149"
           value="value1"
         >
           label1
@@ -40,7 +40,7 @@ describe('MenuSelect component', () => {
           )
         </option>
         <option
-          className="jsx-2370241207"
+          className="jsx-840549149"
           value="value2"
         >
           label2
@@ -49,7 +49,7 @@ describe('MenuSelect component', () => {
           )
         </option>
         <option
-          className="jsx-2370241207"
+          className="jsx-840549149"
           value="value3"
         >
           label3

--- a/components/menu-select/menu-select.tsx
+++ b/components/menu-select/menu-select.tsx
@@ -42,6 +42,7 @@ const MenuSelect = ({
           font-family: 'Roboto', Arial, sans-serif;
           font-weight: ${theme.fonts.weight.regular};
           font-size: ${theme.fonts.size.small};
+          margin: 6px 0;
           margin-right: 20px;
           width: 320px;
           background-color: #2d3640;
@@ -52,12 +53,25 @@ const MenuSelect = ({
           background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='80' height='80' fill='%23999'><polygon points='0,0 80,0 40,40'/></svg>")
             no-repeat;
           background-size: 12px;
-          background-position: calc(100% - 5px) 10px;
+          background-position: calc(100% - 8px) 12px;
           background-repeat: no-repeat;
         }
 
         select.selected {
           background-color: #fff;
+        }
+
+        @media (max-width: ${theme.layout.widePageWidth}) {
+          select {
+            width: 180px;
+          }
+        }
+
+        @media (max-width: ${theme.layout.narrowPageWidth}) {
+          select {
+            width: 220px;
+            margin-right: 0;
+          }
         }
       `}</style>
     </>

--- a/components/tag-chips/tag-chips.tsx
+++ b/components/tag-chips/tag-chips.tsx
@@ -5,7 +5,7 @@ import React, { ReactElement } from 'react';
 const buildUrl = (tag: string): string =>
   `/?${qs.stringify({ menu: { [process.env.TAGS_FACET_FIELD as string]: tag } })}`;
 
-const TagChips = ({ tags }: { tags: string[] }): ReactElement => {
+const TagChips = ({ tags = [] }: { tags: string[] }): ReactElement => {
   if (!process.env.TAGS_FACET_FIELD) {
     return <></>;
   }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Facet bar elements overflow on smaller devices


## What is the new behavior?
Facets bar elements now wrap around without overflowing the display when viewed on smaller devices

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


