### PR TITLE
fix(tag chips): adding overflow ellipsis and setting a max width for tag chips

### DIFF
--- a/components/tag-chips/tag-chips.tsx
+++ b/components/tag-chips/tag-chips.tsx
@@ -15,7 +15,7 @@ const TagChips = ({ tags = [] }: { tags: string[] }): ReactElement => {
     <>
       <div className="tag-chips">
         {tagsToDisplay.map(tag => (
-          <span
+          <div
             key={tag}
             onClick={e => {
               e.preventDefault();
@@ -24,15 +24,16 @@ const TagChips = ({ tags = [] }: { tags: string[] }): ReactElement => {
             }}
           >
             {tag}
-          </span>
+          </div>
         ))}
       </div>
       <style jsx>{`
         div.tag-chips {
-          padding: 45px 0px 30px 15px;
+          padding: 45px 15px 30px 15px;
         }
 
-        span {
+        .tag-chips > div {
+          display: inline-block;
           border-radius: 20px;
           padding: 10px 14px;
           background-color: #f2f2f2;
@@ -42,14 +43,18 @@ const TagChips = ({ tags = [] }: { tags: string[] }): ReactElement => {
           color: #999;
           transition: all 0.3s;
           cursor: pointer;
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+          max-width: 100%;
         }
 
-        span:hover {
+        .tag-chips > div:hover {
           background-color: #e5e5e5;
           color: #333;
         }
 
-        span.active {
+        .tag-chips > div.active {
           border 2px solid hotpink;
         }
       `}</style>

--- a/tests/pages/__snapshots__/blog.spec.tsx.snap
+++ b/tests/pages/__snapshots__/blog.spec.tsx.snap
@@ -96,26 +96,26 @@ exports[`Blog page renders Blog page with content 1`] = `
           </div>
         </section>
         <div
-          className="jsx-4264009547 tag-chips"
+          className="jsx-3439215139 tag-chips"
         >
-          <span
-            className="jsx-4264009547"
+          <div
+            className="jsx-3439215139"
             onClick={[Function]}
           >
             sir blog
-          </span>
-          <span
-            className="jsx-4264009547"
+          </div>
+          <div
+            className="jsx-3439215139"
             onClick={[Function]}
           >
             you're it
-          </span>
-          <span
-            className="jsx-4264009547"
+          </div>
+          <div
+            className="jsx-3439215139"
             onClick={[Function]}
           >
             No tiggy backs
-          </span>
+          </div>
         </div>
         <section
           className="jsx-3528769338"
@@ -194,26 +194,26 @@ exports[`Blog page renders Blog page with content 1`] = `
         </section>
       </div>
       <div
-        className="jsx-4264009547 tag-chips"
+        className="jsx-3439215139 tag-chips"
       >
-        <span
-          className="jsx-4264009547"
+        <div
+          className="jsx-3439215139"
           onClick={[Function]}
         >
           sir blog
-        </span>
-        <span
-          className="jsx-4264009547"
+        </div>
+        <div
+          className="jsx-3439215139"
           onClick={[Function]}
         >
           you're it
-        </span>
-        <span
-          className="jsx-4264009547"
+        </div>
+        <div
+          className="jsx-3439215139"
           onClick={[Function]}
         >
           No tiggy backs
-        </span>
+        </div>
       </div>
       <div
         className="jsx-113928496 content-footer"


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Chip tags are wrapping when the tag name is too long.


## What is the new behavior?
Tag chips are now restricted to 100% width and ellipsis when they overflow.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

