### PR TITLE
fix(blog card): fixing the width of blog card tags

### DIFF
--- a/components/blog-list/__snapshots__/blog-list.spec.tsx.snap
+++ b/components/blog-list/__snapshots__/blog-list.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`BlogList renders blog list with a single blog 1`] = `
 <section
-  className="jsx-526258296"
+  className="jsx-2721295117"
 >
   <div
     className="blog-card-mock"
@@ -12,7 +12,7 @@ exports[`BlogList renders blog list with a single blog 1`] = `
 
 exports[`BlogList renders empty blog list when blog list is empty array 1`] = `
 <section
-  className="jsx-526258296"
+  className="jsx-2721295117"
 >
   
 </section>
@@ -20,7 +20,7 @@ exports[`BlogList renders empty blog list when blog list is empty array 1`] = `
 
 exports[`BlogList renders empty blog list when blog list is undefined 1`] = `
 <section
-  className="jsx-526258296"
+  className="jsx-2721295117"
 >
   
 </section>

--- a/components/blog-list/blog-list.tsx
+++ b/components/blog-list/blog-list.tsx
@@ -16,7 +16,7 @@ const BlogList = ({ blogPosts = [] }: BlogListProps): ReactElement => {
       <style jsx>{`
         section {
           display: grid;
-          grid-template-columns: repeat(3, 1fr);
+          grid-template-columns: repeat(3, minmax(0, 1fr));
           grid-gap: 55px 30px;
           grid-auto-rows: minmax(100px, auto);
           margin: auto;
@@ -28,7 +28,7 @@ const BlogList = ({ blogPosts = [] }: BlogListProps): ReactElement => {
           section {
             grid-template-columns: repeat(2, 1fr);
             padding: 0 20px;
-            margin-top: 0;
+            margin-top: 20px;
           }
         }
 

--- a/components/tag-chips/tag-chips.tsx
+++ b/components/tag-chips/tag-chips.tsx
@@ -46,7 +46,7 @@ const TagChips = ({ tags = [] }: { tags: string[] }): ReactElement => {
           overflow: hidden;
           white-space: nowrap;
           text-overflow: ellipsis;
-          max-width: 100%;
+          max-width: 220px;
         }
 
         .tag-chips > div:hover {

--- a/tests/pages/__snapshots__/blog.spec.tsx.snap
+++ b/tests/pages/__snapshots__/blog.spec.tsx.snap
@@ -96,22 +96,22 @@ exports[`Blog page renders Blog page with content 1`] = `
           </div>
         </section>
         <div
-          className="jsx-3439215139 tag-chips"
+          className="jsx-1065517858 tag-chips"
         >
           <div
-            className="jsx-3439215139"
+            className="jsx-1065517858"
             onClick={[Function]}
           >
             sir blog
           </div>
           <div
-            className="jsx-3439215139"
+            className="jsx-1065517858"
             onClick={[Function]}
           >
             you're it
           </div>
           <div
-            className="jsx-3439215139"
+            className="jsx-1065517858"
             onClick={[Function]}
           >
             No tiggy backs
@@ -194,22 +194,22 @@ exports[`Blog page renders Blog page with content 1`] = `
         </section>
       </div>
       <div
-        className="jsx-3439215139 tag-chips"
+        className="jsx-1065517858 tag-chips"
       >
         <div
-          className="jsx-3439215139"
+          className="jsx-1065517858"
           onClick={[Function]}
         >
           sir blog
         </div>
         <div
-          className="jsx-3439215139"
+          className="jsx-1065517858"
           onClick={[Function]}
         >
           you're it
         </div>
         <div
-          className="jsx-3439215139"
+          className="jsx-1065517858"
           onClick={[Function]}
         >
           No tiggy backs


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Long tag names are forcing the card to expand outside it's intended dimensions


## What is the new behavior?
Long tag are limited by a max width.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

