### PR TITLE
fix(index): scrolling to page top when tag chips are clicked

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -90,6 +90,7 @@ const Index: NextPage<IndexProps> = ({ title, heading, searchPlaceHolder, buildT
       >
         <Configure hitsPerPage={process.env.HITS_PER_PAGE} />
         <ScrollTo scrollOn="page" />
+        <ScrollTo scrollOn="menu" />
         <HeroBanner heading={heading}>
           <HeaderSearchBox placeholderText={searchPlaceHolder} />
           <HeaderFacetBar

--- a/tests/pages/__snapshots__/index.spec.tsx.snap
+++ b/tests/pages/__snapshots__/index.spec.tsx.snap
@@ -26,6 +26,9 @@ exports[`Index components should render index 1`] = `
     <ConnectorWrapper
       scrollOn="page"
     />
+    <ConnectorWrapper
+      scrollOn="menu"
+    />
     <HeroBanner
       heading="heading"
     >


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
When clicking blog card tag chips the page would remain where it was or scroll to the bottom of the page


## What is the new behavior?
Clicking tag chips now scroll the view to the top of the page


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

