### PR TITLE
fix: custom payload limit has been reduced to support large blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,30 +121,28 @@ Next we have to customize the webhook payload, as we want change some of the dat
 ```handlebars
 {
   "_meta": {{{JSONstringify _meta}}},
-  "title": "{{{title}}}",
-  "description": "{{{description}}}",
+  "title": {{{JSONstringify title}}},
+  "description": {{{JSONstringify description}}},
   "deliveryKey": "{{{_meta.deliveryKey}}}",
   "schema": "{{{_meta.schema}}}",
   "authors": [
-    {{#each authors}}{{#if @index}},{{/if}}
-      {
-        "name":"{{{name}}}"
-      }
-    {{/each}}
+    {{~#each authors}}{{#if @index}},{{/if~}}
+      { "name":"{{{name}}}" }
+    {{~/each~}}
   ],
-  {{#if tags}}
+  {{#if tags~}}
     "tags": {{{JSONstringify tags}}},
-  {{/if}}
+  {{~/if~}}
   "date": "{{{this.date}}}",
   "dateAsTimeStamp": {{{moment date format="X"}}},
   "readTime": {{{readTime}}},
   "content": [
-  {{#each content}}
-    {{#if text}}
-      {{#if @index}},{{/if}}
-      {{{JSONstringify text}}}
-    {{/if}}
-  {{/each}}
+  {{~#each (first content 2) ~}}
+    {{~#if text~}}
+      {{~#if @index~}},{{~/if~}}
+      {{{JSONstringify (sanitize (markdown text) ) }}}
+    {{~/if~}}
+  {{~/each~}}
   ],
   "image": {{{JSONstringify image}}}
 }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Webhooks were failing for large blog posts


## What is the new behavior?
- Only processes the first 2 content items and strips out any markdown and html tags
- Removes whites from JSON
- Fixes an issue if the description spans two lines

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


## Other information
