### PR TITLE
docs(readme.md): reinstate content array in custom payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Notes:
 
 - `npm run sync` imports the content-type-schemas and content-types as well as synchronizing any content type changes to your content items.
 
-- Alternatively you can create the schemas and register the content types listed above manually in Dynamic Content.
+- The [CLI definitions](/dc-cli-definitions) assume that your hub contains a repository called 'content'. If your repository name is different you will need to update the definitions.
+
+- If you do not want to use the CLI, you can create the schemas and register the content types listed above manually in Dynamic Content.
 
 ### Creating a Blog content item
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ How to create a blog content item for your blog:
 3. Click "Create content"
 4. Select the "Blog" (or whatever label to assigned to the "blog.json" content type)
 5. Enter a title, heading and search placeholder (these will appear on your blog)
-6. Click "Save"
-7. Click on the "Save" drop down menu, select "Delivery Key" and enter "blog" (you may enter another value if you wish), this value will be used later on to retrieve the blog during the build phase.
+6. Enter enter "blog" in the field _meta > Delivery key (you may enter another value if you wish). This value will be used later on to retrieve the blog during the build phase.
+7. Click "Save"
 8. Click "Publish". The blog must be published for it to be available to the Netlify build process later, otherwise the build will fail.
 
 ### Creating a production search index for your published blog-posts
@@ -87,7 +87,7 @@ On your index select the "Configure" tab and paste in the following configuratio
 
 ```json
 {
-  "searchableAttributes": ["title", "description"],
+  "searchableAttributes": ["title", "description", "content"],
   "customRanking": ["desc(dateAsTimeStamp)"],
   "attributesForFaceting": ["tags", "authors.name"]
 }
@@ -97,7 +97,7 @@ Note that the dateAsTimeStamp attribute used for ranking and sorting will not be
 
 #### Add sort options
 
-For the sort-by drop menu to work we need to create the following 4 sort options
+For the sort-by drop menu to work we need to create the following sort options
 
 | Property        | Ordering   |
 | --------------- | ---------- |
@@ -136,6 +136,14 @@ Next we have to customize the webhook payload, as we want change some of the dat
   "date": "{{{this.date}}}",
   "dateAsTimeStamp": {{{moment date format="X"}}},
   "readTime": {{{readTime}}},
+  "content": [
+  {{~#each content}}
+    {{~#if text~}}
+      {{~#if @index~}},{{~/if~}}
+      {{{JSONstringify (sanitize (markdown text) ) }}}
+    {{~/if~}}
+  {{~/each~}}
+  ],
   "image": {{{JSONstringify image}}}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ How to create a blog content item for your blog:
 3. Click "Create content"
 4. Select the "Blog" (or whatever label to assigned to the "blog.json" content type)
 5. Enter a title, heading and search placeholder (these will appear on your blog)
-6. Enter enter "blog" in the field _meta > Delivery key (you may enter another value if you wish). This value will be used later on to retrieve the blog during the build phase.
+6. Enter "blog" in the field _meta > Delivery key (you may enter another value if you wish). This value will be used later on to retrieve the blog during the build phase.
 7. Click "Save"
 8. Click "Publish". The blog must be published for it to be available to the Netlify build process later, otherwise the build will fail.
 


### PR DESCRIPTION
Reinstating the content array in the documented custom payload in the README. This is because the code relies on the content array - without it no blog posts will appear in the blog listing.

Also made some minor README improvements based on user feedback.

## Pull request checklist
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Content array not in custom payload - no blogcards display on listing page.

## What is the new behavior?
Content array is in custom payload - blogcards display on listing page.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No


