### PR TITLE
docs(readme): updated to add a comma in the handlebars if not the last array element

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ Next we have to customize the webhook payload, as we want change some of the dat
   "deliveryKey": "{{{_meta.deliveryKey}}}",
   "schema": "{{{_meta.schema}}}",
   "authors": [
-    {{~#each authors}}{{#if @index}},{{/if~}}
-      { "name":"{{{name}}}" }
-    {{~/each~}}
+    {{~#forEach authors}}
+      { "name":"{{{name}}}" }{{#unless isLast}},{{/unless~}}
+    {{~/forEach~}}
   ],
   {{#if tags~}}
     "tags": {{{JSONstringify tags}}},
@@ -139,12 +139,11 @@ Next we have to customize the webhook payload, as we want change some of the dat
   "dateAsTimeStamp": {{{moment date format="X"}}},
   "readTime": {{{readTime}}},
   "content": [
-  {{~#each content}}
+  {{~#forEach content}}
     {{~#if text~}}
-      {{~#if @index~}},{{~/if~}}
-      {{{JSONstringify (sanitize (markdown text) ) }}}
+      {{{JSONstringify (sanitize (markdown text) ) }}}{{#unless isLast}},{{/unless~}}
     {{~/if~}}
-  {{~/each~}}
+  {{~/forEach~}}
   ],
   "image": {{{JSONstringify image}}}
 }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Handlebars in the readme will currently add a comma to an empty array value causing the output to be invalid JSON.


## What is the new behavior?
Added a different each method which has a `isLast` variable making it easier to add commas when none empty values.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

