### PR TITLE
fix: only append / to urls that dont end in / (external lib change)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15257,9 +15257,8 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nextjs-sitemap-generator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/nextjs-sitemap-generator/-/nextjs-sitemap-generator-1.1.3.tgz",
-      "integrity": "sha512-CNZ9pN4FNsXvkhtU7o2yPkyxEIsjwWJxGNLTDYApRJhdtZ0FfZzPleRHFCJPdbtiMXKLdRjBlfQFkgWsoOMGrw==",
+      "version": "github:easen-amp/nextjs-sitemap-generator#2162fcb1a50142097f84b72ac51b249757a89129",
+      "from": "github:easen-amp/nextjs-sitemap-generator#master",
       "requires": {
         "date-fns": "^2.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "debounce": "^1.2.0",
     "isomorphic-unfetch": "^3.0.0",
     "next": "^9.4.4",
-    "nextjs-sitemap-generator": "^1.1.3",
+    "nextjs-sitemap-generator": "easen-amp/nextjs-sitemap-generator#master",
     "promise.allsettled": "^1.0.2",
     "qs": "^6.9.4",
     "react": "^16.13.1",


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): dependency  


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

nextjs-sitemap-generator appends a / before checking the url already ends in /


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- added a check to see if the path ends in a / before adding another one (https://github.com/IlusionDev/nextjs-sitemap-generator/pull/71)


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR -->

